### PR TITLE
refactor: standardize clonotypic_entropy + phenotypic_entropy API

### DIFF
--- a/tcri/metrics/_metrics.py
+++ b/tcri/metrics/_metrics.py
@@ -227,63 +227,56 @@ def clonotypic_entropy_base(
 def clonotypic_entropy(
     adata,
     covariate: str,
-    phenotype: str,
     *,
+    point_estimate: bool = True,
+    n_samples: int = 200,
     temperature: float = 1.0,
-    n_samples: int = 0,           # 0 → single value
-    clones: Optional[List[str]] = None,
-    weighted: bool = False,
-    normalised: bool = True,
-    base: int = 2,
-    posterior: bool = True,
     combine_with_logits: bool = True,
-    verbose: bool = True,
-    graph: bool = False,          # ASCII bar plot of posterior
-) -> Union[float, np.ndarray]:
+    _clones: Optional[List[str]] = None,
+) -> Union[pd.Series, np.ndarray]:
+    """
+    H[ P(C | P=p, T=covariate) ] for every phenotype p.
 
-    if verbose:
-        print(f"{BOLD}{MAG}🧮  Clonotypic entropy – {phenotype} @ '{covariate}'{RESET}")
-        _info("posterior",      posterior)
-        _info("weighted",       weighted)
-        _info("# samples",      n_samples)
+    Returns
+    -------
+    point_estimate=True  -> pd.Series indexed by phenotype name,
+                            values are mean H over n_samples posterior draws.
+    point_estimate=False -> np.ndarray of shape (n_samples, n_phenotypes).
+    """
+    if n_samples < 1:
+        raise ValueError("n_samples must be >= 1")
 
-    # ---- single deterministic draw ---------------------------------
-    if n_samples == 0:
-        H = clonotypic_entropy_base(
-                adata, covariate, phenotype,
-                base               = base,
-                normalised         = normalised,
-                temperature        = temperature,
-                clones             = clones,
-                weighted           = weighted,
-                posterior          = posterior,
-                combine_with_logits= combine_with_logits)
-        if verbose:
-            _ok(f"H = {H:.4f}")
-        return H
+    phenotypes = list(adata.uns["tcri_phenotype_categories"])
+    n_pheno = len(phenotypes)
+    samples = np.empty((n_samples, n_pheno), dtype=float)
 
-    # ---- Monte-Carlo sampling --------------------------------------
-    H_samp = np.empty(n_samples, dtype=float)
     for i in range(n_samples):
-        H_samp[i] = clonotypic_entropy_base(
-            adata, covariate, phenotype,
-            base               = base,
-            normalised         = normalised,
-            temperature        = temperature,
-            clones             = clones,
-            weighted           = weighted,
-            posterior          = posterior,
-            combine_with_logits= combine_with_logits)
+        jd = joint_distribution_posterior(
+            adata,
+            covariate_label     = covariate,
+            temperature         = temperature,
+            clones              = _clones,
+            combine_with_logits = combine_with_logits,
+            silent              = True,
+        )
+        if jd is None or jd.empty:
+            samples[i, :] = 0.0
+            continue
+        for j, p in enumerate(phenotypes):
+            if p not in jd.columns:
+                samples[i, j] = 0.0
+                continue
+            vec = jd[p].to_numpy(dtype=float)
+            vec = np.clip(vec, 1e-15, None)
+            vec = vec / vec.sum()
+            H = entropy(vec, base=2)
+            if len(vec) > 1:
+                H /= np.log2(len(vec))
+            samples[i, j] = H
 
-    if verbose:
-        _ok("sampling complete")
-        _info("mean ± sd",  f"{H_samp.mean():.4f} ± {H_samp.std():.4f}")
-        lo,hi = np.percentile(H_samp,[2.5,97.5])
-        _info("95 % CI",    f"[{lo:.4f}, {hi:.4f}]")
-        if graph:
-            print(f"{DIM}\nASCII histogram:\n{_ascii_hist(H_samp)}{RESET}")
-
-    return H_samp
+    if point_estimate:
+        return pd.Series(samples.mean(axis=0), index=phenotypes, name=covariate)
+    return samples
 
 def delta_clonotypic_entropy(
     adata,
@@ -433,122 +426,70 @@ def delta_entropy_table(
 
 def phenotypic_entropy(
     adata,
-    covariate              : str,
+    covariate: str,
     *,
-    clonotypes             : Optional[Union[str,List[str]]] = None,
-    base                   : int   = 2,
-    normalised             : bool  = True,
-    temperature            : float = 1.0,
-    n_samples              : int   = 0,
-    weighted               : bool  = False,
-    posterior              : bool  = True,
-    combine_with_logits    : bool  = True,
-    verbose                : bool  = True,
-    graph                  : bool  = False,
-    seed                   : Optional[int] = 42
-) -> Union[float, np.ndarray]:
+    point_estimate: bool = True,
+    n_samples: int = 200,
+    temperature: float = 1.0,
+    combine_with_logits: bool = True,
+) -> Union[pd.Series, np.ndarray]:
+    """
+    H[ P(P | C=c, T=covariate) ] for every clone c present at the covariate.
 
-    if seed is not None:
-        np.random.seed(seed)
+    Returns
+    -------
+    point_estimate=True  -> pd.Series indexed by clone name,
+                            values are mean H over n_samples posterior draws.
+    point_estimate=False -> np.ndarray of shape (n_samples, n_clones).
+    """
+    if n_samples < 1:
+        raise ValueError("n_samples must be >= 1")
 
-    # ── header ────────────────────────────────────────────────── #
-    if verbose:
-        print(f"{BOLD}{MAG}📈  Phenotypic-entropy at '{covariate}'{RESET}")
-        _info("posterior",   posterior,   False)
-        _info("n_samples",   n_samples,   False)
-        _info("normalised",  normalised,  False)
+    meta          = adata.uns["tcri_metadata"]
+    clone_col     = meta["clone_col"]
+    covariate_col = meta["covariate_col"]
 
-    # ── pull meta info ----------------------------------------- #
-    meta           = adata.uns["tcri_metadata"]
-    clone_col      = meta["clone_col"]
-    covariate_col  = meta["covariate_col"]
-
-    # determine clonotype list
-    if clonotypes is None:
-        clones_list = (
-            adata.obs.loc[adata.obs[covariate_col] == covariate, clone_col]
-            .unique()
-            .tolist()
-        )
-    elif isinstance(clonotypes, str):
-        clones_list = [clonotypes]
-    else:
-        clones_list = clonotypes
+    clones_list = (
+        adata.obs.loc[adata.obs[covariate_col] == covariate, clone_col]
+        .unique()
+        .tolist()
+    )
 
     if len(clones_list) == 0:
-        _warn("no clonotypes found – returning 0", quiet=not verbose)
-        return 0.0
+        if point_estimate:
+            return pd.Series(dtype=float, name=covariate)
+        return np.empty((n_samples, 0), dtype=float)
 
-    log_base = np.log(base)
+    n_clones = len(clones_list)
+    samples = np.empty((n_samples, n_clones), dtype=float)
 
-    # ── ONE posterior/prior draw → mean entropy across clones ── #
-    def _one_sample() -> float:
-        if posterior:
-            jd = joint_distribution_posterior(
-                    adata,
-                    covariate_label     = covariate,
-                    temperature         = temperature,
-                    clones              = clones_list,
-                    weighted            = weighted,
-                    combine_with_logits = combine_with_logits,
-                    silent              = True)
-        else:
-            jd = joint_distribution(
-                    adata,
-                    covariate_label = covariate,
-                    temperature     = temperature,
-                    n_samples       = 0,
-                    clones          = clones_list,
-                    weighted        = weighted)
-
-        if jd is None or jd.empty:
-            return 0.0
-        ent_vals = []
-        for cl in clones_list:
-            if cl not in jd.index:
-                continue
-            p   = jd.loc[cl].to_numpy(dtype=float)
-            eps = 1e-15
-            p   = p.clip(eps)
-            h   = entropy(p, base=base)
-            if normalised:
-                h /= np.log(len(p)) / log_base
-            ent_vals.append(h)
-        return float(np.mean(ent_vals)) if ent_vals else 0.0
-
-    # ── no-sampling branch ------------------------------------ #
-    if n_samples == 0:
-        val = _one_sample()
-        _ok("entropy computed", quiet=not verbose)
-        if verbose:
-            _info("value", f"{val:.4f}")
-            _fin()
-        return val
-
-    # ── Monte-Carlo sampling ---------------------------------- #
-    samples = np.empty(n_samples, dtype=float)
     for i in range(n_samples):
-        samples[i] = _one_sample()
+        jd = joint_distribution_posterior(
+            adata,
+            covariate_label     = covariate,
+            temperature         = temperature,
+            clones              = clones_list,
+            combine_with_logits = combine_with_logits,
+            silent              = True,
+        )
+        if jd is None or jd.empty:
+            samples[i, :] = 0.0
+            continue
+        n_phen = jd.shape[1]
+        norm = np.log2(n_phen) if n_phen > 1 else 1.0
+        for j, cl in enumerate(clones_list):
+            if cl not in jd.index:
+                samples[i, j] = 0.0
+                continue
+            p = jd.loc[cl].to_numpy(dtype=float)
+            p = np.clip(p, 1e-15, None)
+            p = p / p.sum()
+            samples[i, j] = entropy(p, base=2) / norm
 
-    if verbose:
-        _ok(f"generated {n_samples:,} samples")
-        _info("mean ± sd", f"{samples.mean():.4f} ± {samples.std():.4f}")
-        _info("95% CI",
-              f"[{np.percentile(samples,2.5):.4f}, "
-              f"{np.percentile(samples,97.5):.4f}]")
-        if graph:
-            print(f"{DIM}\nASCII histogram:\n{_ascii_hist(samples)}{RESET}")
-        _fin()
-
+    if point_estimate:
+        return pd.Series(samples.mean(axis=0), index=clones_list, name=covariate)
     return samples
 
-def clonotypic_entropies(adata, covariate, normalized=True, base=2, temperature=1., decimals=5, n_samples=0):
-    unique_phenotypes = adata.uns["tcri_phenotype_categories"]
-    phenotype_entropies = dict()
-    for phenotype in unique_phenotypes:
-        cent = clonotypic_entropy(adata, covariate, phenotype, temperature=temperature)
-        phenotype_entropies[phenotype] = np.round(cent,decimals=decimals)
-    return phenotype_entropies
 
 def clonality(adata):
     phenotypes = adata.obs[adata.uns["tcri_phenotype_key"]].tolist()
@@ -586,7 +527,6 @@ def mutual_information(
     temperature: float = 1.0,
     n_samples: int = 0,
     clones: Optional[List[str]] = None,
-    weighted: bool = False,
     normalised: bool = True,
     normalise_mode: str = "average",
     posterior: bool = True,
@@ -597,14 +537,13 @@ def mutual_information(
     """
     MI between clonotype and phenotype at one covariate value.
 
-    posterior=True  → Dirichlet draw of p_ct (+ optional logits)  
+    posterior=True  → Dirichlet draw of p_ct (+ optional logits)
     posterior=False → prior-only (uses your original joint_distribution).
     """
 
     if verbose:
         print(f"{BOLD}{MAGENT}📊  MI for '{covariate}'{RESET}")
         _info("posterior",  posterior)
-        _info("weighted",   weighted)
         _info("n_samples",  n_samples)
 
     # helper to obtain *one* joint table
@@ -615,7 +554,6 @@ def mutual_information(
                 covariate_label     = covariate,
                 temperature         = temperature,
                 clones              = clones,
-                weighted            = weighted,
                 combine_with_logits = combine_with_logits,
                 silent              = silent_flag,
             )

--- a/tcri/plotting/_plotting.py
+++ b/tcri/plotting/_plotting.py
@@ -620,10 +620,7 @@ def clonotypic_entropy_by_phenotype(
     adata,
     *,
     temperature       = 1.0,
-    n_samples         = 0,
-    weighted          = False,
-    normalised        = True,
-    posterior         = True,
+    n_samples         = 200,
     combine_with_logits = True,
     bayesian          = True,
     bayes_samples     = 1_000,
@@ -653,48 +650,43 @@ def clonotypic_entropy_by_phenotype(
 
     if hue_order is None:
         hue_order = covariates
-    # # ---- colours -------------------------------------------------- #
-    # if group_colors is not None:
-    #     palette = tcri.pl.tcri_colors#[group_colors[c] for c in hue_order]
-    # elif palette is None:
-    #     palette = sns.color_palette("Set2", len(hue_order))
     palette=tcri_colors
     cov2col = dict(zip(hue_order, palette))
 
     # ---- compute entropy values ----------------------------------- #
     records = []
-    iterator = itertools.product(batches, hue_order, phenotypes)
+    iterator = list(itertools.product(batches, hue_order))
     if progress:
-        iterator = tqdm.tqdm(list(iterator), desc="clonotypic entropy")
+        iterator = tqdm.tqdm(iterator, desc="clonotypic entropy")
 
-    for patient, cov_value, phen in iterator:
-        mask = (
+    for patient, cov_value in iterator:
+        mask_pc = (
             (adata.obs[batch_col] == patient) &
-            (adata.obs[cov_col]   == cov_value) &
-            (adata.obs[phen_col]  == phen)
+            (adata.obs[cov_col]   == cov_value)
         )
-        sub = adata[mask]
-        if sub.n_obs == 0:
+        if not mask_pc.any():
             continue
-        clones = list(set(sub.obs["trb_unique"]))
-        ent = centropy(
+        clones = list(set(adata.obs.loc[mask_pc, "trb_unique"]))
+        if not clones:
+            continue
+        ent_series = centropy(
             adata,
             covariate          = cov_value,
-            phenotype          = phen,
-            temperature        = temperature,
+            point_estimate     = True,
             n_samples          = n_samples,
-            weighted           = weighted,
-            clones             = clones,
-            normalised         = normalised,
-            posterior          = posterior,
+            temperature        = temperature,
             combine_with_logits= combine_with_logits,
-            verbose            = False,
+            _clones            = clones,
         )
-        ent_scalar = float(ent)  # always scalar now
-        records.append(
-            {cov_col: cov_value, batch_col: patient,
-             phen_col: phen, "entropy": ent_scalar}
-        )
+        for phen in phenotypes:
+            if not (mask_pc & (adata.obs[phen_col] == phen)).any():
+                continue
+            if phen not in ent_series.index:
+                continue
+            records.append(
+                {cov_col: cov_value, batch_col: patient,
+                 phen_col: phen, "entropy": float(ent_series[phen])}
+            )
 
     df = pd.DataFrame.from_records(records)
     if df.empty:

--- a/tests/test_metrics/test_metrics.py
+++ b/tests/test_metrics/test_metrics.py
@@ -1,96 +1,88 @@
-import pytest
 import numpy as np
+import pandas as pd
+import pytest
+
 from tcri.metrics._metrics import (
     clonotypic_entropy,
     phenotypic_entropy,
     mutual_information,
-    clonality
+    clonality,
 )
 
-@pytest.mark.xfail(strict=False, reason="X_tcri_logits not populated by mock_adata fixture; tracked in T2 fixture alignment")
-def test_clonotypic_entropy(mock_adata, mock_joint_distribution):
-    """Test clonotypic_entropy function."""
-    # Test with mock data
-    entropy_val = clonotypic_entropy(
-        mock_adata,
-        covariate="T1",
-        phenotype="A",
-        temperature=1.0
-    )
-    
-    # Check that entropy is between 0 and 1 (normalized)
-    assert 0 <= entropy_val <= 1
-    
-    # Test with different temperature
-    entropy_val_temp = clonotypic_entropy(
-        mock_adata,
-        covariate="T1",
-        phenotype="A",
-        temperature=0.5
-    )
-    assert entropy_val_temp != entropy_val  # Should be different with different temperature
 
-@pytest.mark.xfail(strict=False, reason="phenotypic_entropy API drifted; mock fixture passes removed clonotype kwarg; tracked in T2")
-def test_phenotypic_entropy(mock_adata, mock_joint_distribution):
-    """Test phenotypic_entropy function."""
-    # Test with mock data
-    entropy_val = phenotypic_entropy(
-        mock_adata,
-        covariate="T1",
-        clonotype="clone_0",
-        temperature=1.0
-    )
-    
-    # Check that entropy is between 0 and 1 (normalized)
-    assert 0 <= entropy_val <= 1
-    
-    # Test with different temperature
-    entropy_val_temp = phenotypic_entropy(
-        mock_adata,
-        covariate="T1",
-        clonotype="clone_0",
-        temperature=0.5
-    )
-    assert entropy_val_temp != entropy_val  # Should be different with different temperature
+def test_clonotypic_entropy(trained_model):
+    _, adata = trained_model
+    covariate = adata.uns["tcri_covariate_categories"][0]
+    phenotypes = adata.uns["tcri_phenotype_categories"]
 
-@pytest.mark.xfail(strict=False, reason="X_tcri_logits not populated by mock_adata fixture; tracked in T2 fixture alignment")
-def test_mutual_information(mock_adata, mock_joint_distribution):
-    """Test mutual_information function."""
-    # Test with mock data
-    mi_val = mutual_information(
-        mock_adata,
-        covariate="T1",
-        temperature=1.0
+    s = clonotypic_entropy(adata, covariate, n_samples=20)
+    assert isinstance(s, pd.Series)
+    assert list(s.index) == list(phenotypes)
+    vals = s.to_numpy()
+    assert np.all(np.isfinite(vals))
+    assert np.all(vals >= 0)
+
+    arr = clonotypic_entropy(
+        adata, covariate, point_estimate=False, n_samples=5
     )
-    
-    # Check that MI is non-negative
-    assert mi_val >= 0
-    
-    # Test with different temperature
-    mi_val_temp = mutual_information(
-        mock_adata,
-        covariate="T1",
-        temperature=0.5
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape == (5, len(phenotypes))
+    assert np.all(np.isfinite(arr))
+    assert np.all(arr >= 0)
+
+    with pytest.raises(ValueError):
+        clonotypic_entropy(adata, covariate, n_samples=0)
+
+
+def test_phenotypic_entropy(trained_model):
+    _, adata = trained_model
+    covariate = adata.uns["tcri_covariate_categories"][0]
+
+    meta = adata.uns["tcri_metadata"]
+    expected_clones = (
+        adata.obs.loc[adata.obs[meta["covariate_col"]] == covariate, meta["clone_col"]]
+        .unique()
+        .tolist()
     )
-    assert mi_val_temp != mi_val  # Should be different with different temperature
-    
-    # Test with weighted=True
-    mi_val_weighted = mutual_information(
-        mock_adata,
-        covariate="T1",
-        temperature=1.0,
-        weighted=True
+
+    s = phenotypic_entropy(adata, covariate, n_samples=20)
+    assert isinstance(s, pd.Series)
+    assert set(s.index) == set(expected_clones)
+    vals = s.to_numpy()
+    assert np.all(np.isfinite(vals))
+    assert np.all(vals >= 0)
+
+    arr = phenotypic_entropy(
+        adata, covariate, point_estimate=False, n_samples=5
     )
-    assert mi_val_weighted != mi_val  # Should be different when weighted
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape == (5, len(expected_clones))
+    assert np.all(np.isfinite(arr))
+    assert np.all(arr >= 0)
+
+    with pytest.raises(ValueError):
+        phenotypic_entropy(adata, covariate, n_samples=0)
+
+
+def test_mutual_information(trained_model):
+    _, adata = trained_model
+    covariate = adata.uns["tcri_covariate_categories"][0]
+
+    mi = mutual_information(adata, covariate=covariate, temperature=1.0, verbose=False)
+    assert np.isfinite(mi)
+    assert mi >= 0
+
+    mi_alt = mutual_information(adata, covariate=covariate, temperature=0.5, verbose=False)
+    assert np.isfinite(mi_alt)
+    assert mi_alt >= 0
+    assert mi_alt != mi
+
 
 def test_clonality(mock_adata):
     """Test clonality function."""
-    # Test with mock data
     clonality_dict = clonality(mock_adata)
-    
-    # Check that clonality values are between 0 and 1
+
     for val in clonality_dict.values():
         assert 0 <= val <= 1
-    
-    # Check that we have clonality values for all phenotypes
-    assert set(clonality_dict.keys()) == set(mock_adata.uns["tcri_phenotype_categories"]) 
+
+    assert set(clonality_dict.keys()) == set(mock_adata.uns["tcri_phenotype_categories"])


### PR DESCRIPTION
Both functions now require a covariate argument and return per-output vectors (Series for point estimate, ndarray for posterior draws).
- Drop `weighted` kwarg (always clone-as-unit)
- Drop public `posterior=False` (cached-only is internal-only)
- Drop per-clone/per-phenotype selection kwargs
- Default n_samples=200; n_samples<1 raises
- Migrate in-repo callers (clonotypic_entropy_by_phenotype uses internal _clones= filter, indexes returned Series by phenotype)
- Delete clonotypic_entropies helper (zero callers, redundant under new contract)
- Drop `weighted` from mutual_information for API consistency
- Rewrite 3 xfailed metrics tests against trained_model fixture; remove xfail markers

Closes Notion T2 (#25). Pre-1.0 hard break, no deprecation shim.