### PR TITLE
fix: use clone_col from metadata; nan fallback for empty entropy rows

### DIFF
--- a/tcri/metrics/_metrics.py
+++ b/tcri/metrics/_metrics.py
@@ -260,11 +260,11 @@ def clonotypic_entropy(
             silent              = True,
         )
         if jd is None or jd.empty:
-            samples[i, :] = 0.0
+            samples[i, :] = np.nan
             continue
         for j, p in enumerate(phenotypes):
             if p not in jd.columns:
-                samples[i, j] = 0.0
+                samples[i, j] = np.nan
                 continue
             vec = jd[p].to_numpy(dtype=float)
             vec = np.clip(vec, 1e-15, None)
@@ -275,7 +275,7 @@ def clonotypic_entropy(
             samples[i, j] = H
 
     if point_estimate:
-        return pd.Series(samples.mean(axis=0), index=phenotypes, name=covariate)
+        return pd.Series(np.nanmean(samples, axis=0), index=phenotypes, name=covariate)
     return samples
 
 def delta_clonotypic_entropy(
@@ -473,13 +473,13 @@ def phenotypic_entropy(
             silent              = True,
         )
         if jd is None or jd.empty:
-            samples[i, :] = 0.0
+            samples[i, :] = np.nan
             continue
         n_phen = jd.shape[1]
         norm = np.log2(n_phen) if n_phen > 1 else 1.0
         for j, cl in enumerate(clones_list):
             if cl not in jd.index:
-                samples[i, j] = 0.0
+                samples[i, j] = np.nan
                 continue
             p = jd.loc[cl].to_numpy(dtype=float)
             p = np.clip(p, 1e-15, None)
@@ -487,7 +487,7 @@ def phenotypic_entropy(
             samples[i, j] = entropy(p, base=2) / norm
 
     if point_estimate:
-        return pd.Series(samples.mean(axis=0), index=clones_list, name=covariate)
+        return pd.Series(np.nanmean(samples, axis=0), index=clones_list, name=covariate)
     return samples
 
 

--- a/tcri/plotting/_plotting.py
+++ b/tcri/plotting/_plotting.py
@@ -666,7 +666,7 @@ def clonotypic_entropy_by_phenotype(
         )
         if not mask_pc.any():
             continue
-        clones = list(set(adata.obs.loc[mask_pc, "trb_unique"]))
+        clones = list(set(adata.obs.loc[mask_pc, clone_col]))
         if not clones:
             continue
         ent_series = centropy(


### PR DESCRIPTION
## Summary
Two pre-existing bugs flagged during T2 review:

- **`clonotypic_entropy_by_phenotype`** hardcoded `"trb_unique"` instead of reading the clone column from `adata.uns["tcri_metadata"]["clone_col"]`. Silently broke on datasets (e.g. Zhang) where the clone column is named differently. The function already loads `meta` and binds `clone_col` a few lines up, so this is a one-line swap.
- **`clonotypic_entropy` and `phenotypic_entropy`** filled empty `(clone, covariate)` cells in the posterior-sample array with `H=0.0`. `H=0` reads as "perfect concentration on a single value", not "no data" — so missing cells biased aggregates downward. Switched the fallback to `np.nan` and the point-estimate reduction from `samples.mean(axis=0)` to `np.nanmean(samples, axis=0)`. Downstream plotting that uses `Series.mean()` already skips nan correctly.

Closes Notion T15 (review-flagged followup).

## Test plan
- [x] `pytest tests/ -v` → **6 passed, 0 xfailed** (the 3 metrics tests previously xfailed now pass cleanly under nan semantics).
- [ ] Spot-check `clonotypic_entropy_by_phenotype` on a dataset whose clone column is not literally `trb_unique`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)