### PR TITLE
chore: strip vestigial Sethna attribution headers (#26)

### DIFF
--- a/tcri/utils/_utils.py
+++ b/tcri/utils/_utils.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-"""
-Copyright (C) 2022 Zachary Sethna
-"""
 from __future__ import print_function, division
 import os
 import sys
@@ -319,12 +315,6 @@ tcri_colors = [
     "#C38D94",  # Muted Rose
     "#6D6A75",  # Purple Gray
 ]
-
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-"""
-Copyright (C) 2022 Zachary Sethna
-"""
 
 import daft
 import matplotlib.pyplot as plt


### PR DESCRIPTION
Final piece of roadmap **#26** — removing the last of the inherited Sethna attribution.

The substantial Sethna-derived code (~2300 LOC of data classes) was already deleted in #14. This removes the two now-stale `Copyright (C) 2022 Zachary Sethna` headers in `tcri/utils/_utils.py` — both sat atop **first-party** code:
- AUC permutation / bootstrap stats helpers
- scvi/pyro session save-load (`save_tcri_session` / `load_tcri_session`)
- `tcri_colors` palette
- the TCRi-model PGM diagram (`build_nested_tcri_pgm`)

Verified: `rg -ni sethna tcri/` returns nothing; `py_compile` clean. No code changes — attribution headers only.

### Note for follow-up (not in this PR)
The one piece intentionally kept from the original Sankey module is `SankeyNode` (`tcri/plotting/_sankey.py`, ~49 lines) — a small generic matplotlib helper, already carrying no attribution, and required by `plot_pheno_sankey`. If the goal is to fully clear GPL provenance (e.g. to **relicense from GPLv3 → MIT** to match genevector), that's the one ~30-min reimplementation to scrutinize. Raising separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)