### PR TITLE
ci: release infrastructure — version bumping + PyPI publish (#22)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install package + test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+      - name: Run tests
+        run: pytest tests/ -v
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+      - name: Check distributions
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # Only publish on an actual version tag push, never on a manual dry-run.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tcri
+    permissions:
+      id-token: write  # OIDC: PyPI Trusted Publishing (no API token needed)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # Uses Trusted Publishing via the OIDC token above. One-time setup on PyPI:
+        # https://docs.pypi.org/trusted-publishers/  ->  project "tcri"  ->  Publishing
+        #   owner: nceglia | repo: tcri | workflow: release.yml | environment: pypi
+        #
+        # Prefer an API token instead? Drop the `permissions:` block above and add:
+        #   with:
+        #     password: ${{ secrets.PYPI_TOKEN }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,14 @@ description = 'Information Theoretic Framework for Paired Single Cell Gene Expre
 copyright = '2022-2025'
 author = 'Nicholas Ceglia'
 
-# The full version, including alpha/beta/rc tags
-release = '0.0.1'
+# The full version, including alpha/beta/rc tags.
+# Single source of truth is pyproject.toml; read it back via installed metadata.
+try:
+    from importlib.metadata import version as _pkg_version
+    release = _pkg_version("tcri")
+except Exception:
+    release = "0.0.0"
+version = release
 
 # -- General configuration ---------------------------------------------------
 

--- a/update_version.py
+++ b/update_version.py
@@ -1,112 +1,89 @@
 #!/usr/bin/env python3
 """
-Script to update the version of the tcri package in setup.py.
+Update the version of the tcri package.
+
+The single source of truth for the version is the ``version`` field in
+``pyproject.toml``. ``tcri.__version__`` and the docs (``docs/conf.py``) both
+read it back via ``importlib.metadata``, so this script only edits
+``pyproject.toml``.
 
 Usage:
-    python update_version.py 0.0.2
-    python update_version.py --major  # Bump major version (e.g., 0.0.1 -> 1.0.0)
-    python update_version.py --minor  # Bump minor version (e.g., 0.0.1 -> 0.1.0)
-    python update_version.py --patch  # Bump patch version (e.g., 0.0.1 -> 0.0.2)
+    python update_version.py 0.2.0     # set an explicit version
+    python update_version.py --major   # 0.1.0 -> 1.0.0
+    python update_version.py --minor   # 0.1.0 -> 0.2.0
+    python update_version.py --patch   # 0.1.0 -> 0.1.1
 """
 
 import re
 import sys
 from pathlib import Path
 
+PYPROJECT = Path(__file__).parent / "pyproject.toml"
+# Match the [project] `version = "X.Y.Z"` line (anchored to start of line).
+VERSION_RE = re.compile(r'(?m)^(version\s*=\s*")([^"]+)(")')
 
-def get_current_version(setup_file: Path) -> str:
-    """Extract current version from setup.py."""
-    content = setup_file.read_text()
-    match = re.search(r"version\s*=\s*['\"]([^'\"]+)['\"]", content)
+
+def get_current_version(text: str) -> str:
+    match = VERSION_RE.search(text)
     if not match:
-        raise ValueError("Could not find version in setup.py")
-    return match.group(1)
+        raise ValueError('Could not find `version = "..."` in pyproject.toml')
+    return match.group(2)
 
 
-def parse_version(version: str) -> tuple[int, int, int]:
-    """Parse version string into (major, minor, patch) tuple."""
-    parts = version.split('.')
+def parse_version(version: str) -> tuple:
+    parts = version.split(".")
     if len(parts) != 3:
-        raise ValueError(f"Invalid version format: {version}. Expected format: X.Y.Z")
+        raise ValueError(f"Invalid version {version!r}; expected X.Y.Z")
     try:
-        return tuple(map(int, parts))
+        return tuple(int(p) for p in parts)
     except ValueError:
-        raise ValueError(f"Invalid version format: {version}. All parts must be integers.")
+        raise ValueError(f"Invalid version {version!r}; all parts must be integers")
 
 
 def bump_version(version: str, part: str) -> str:
-    """Bump the specified part of the version."""
     major, minor, patch = parse_version(version)
-    
-    if part == 'major':
-        major += 1
-        minor = 0
-        patch = 0
-    elif part == 'minor':
-        minor += 1
-        patch = 0
-    elif part == 'patch':
-        patch += 1
-    else:
-        raise ValueError(f"Invalid version part: {part}. Must be 'major', 'minor', or 'patch'.")
-    
-    return f"{major}.{minor}.{patch}"
+    if part == "major":
+        return f"{major + 1}.0.0"
+    if part == "minor":
+        return f"{major}.{minor + 1}.0"
+    if part == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    raise ValueError(f"Invalid part {part!r}; must be major, minor, or patch")
 
 
-def update_version(setup_file: Path, new_version: str) -> None:
-    """Update version in setup.py."""
-    content = setup_file.read_text()
-    
-    # Validate new version format
-    parse_version(new_version)
-    
-    # Replace version in setup.py
-    new_content = re.sub(
-        r"(version\s*=\s*['\"])([^'\"]+)(['\"])",
-        rf"\g<1>{new_version}\g<3>",
-        content
-    )
-    
-    if new_content == content:
-        raise ValueError("Failed to update version in setup.py")
-    
-    setup_file.write_text(new_content)
+def main() -> None:
+    if not PYPROJECT.exists():
+        sys.exit(f"Error: {PYPROJECT} not found")
 
+    text = PYPROJECT.read_text()
+    current = get_current_version(text)
+    print(f"Current version: {current}")
 
-def main():
-    setup_file = Path(__file__).parent / "setup.py"
-    
-    if not setup_file.exists():
-        print(f"Error: {setup_file} not found", file=sys.stderr)
-        sys.exit(1)
-    
-    current_version = get_current_version(setup_file)
-    print(f"Current version: {current_version}")
-    
     if len(sys.argv) != 2:
         print(__doc__)
         sys.exit(1)
-    
+
     arg = sys.argv[1]
-    
-    # Determine new version
-    if arg.startswith('--'):
-        part = arg[2:]
-        if part not in ['major', 'minor', 'patch']:
-            print(f"Error: Invalid argument '{arg}'", file=sys.stderr)
-            print(__doc__)
-            sys.exit(1)
-        new_version = bump_version(current_version, part)
+    if arg.startswith("--"):
+        new_version = bump_version(current, arg[2:])
     else:
+        parse_version(arg)  # validate format
         new_version = arg
-    
-    # Update version
-    try:
-        update_version(setup_file, new_version)
-        print(f"Version updated: {current_version} -> {new_version}")
-    except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
+
+    if new_version == current:
+        print(f"Version already {current}; nothing to do.")
+        return
+
+    new_text = VERSION_RE.sub(rf"\g<1>{new_version}\g<3>", text, count=1)
+    if new_text == text:
+        sys.exit("Error: failed to update version in pyproject.toml")
+
+    PYPROJECT.write_text(new_text)
+    print(f"Version updated: {current} -> {new_version}")
+    print(
+        "Note: tcri.__version__ and the docs read this via importlib.metadata; "
+        "reinstall (pip install -e .) to refresh the installed metadata."
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Roadmap **#22** — release infrastructure (PyPI). Also closes the version-drift item from **#26(c)**.

### What's in this PR (code)
- **`update_version.py`** rewritten to bump the **single version source** (`pyproject.toml`). `tcri.__version__` (from #21) and `docs/conf.py` now both derive the version via `importlib.metadata`, so one edit propagates everywhere.
  - `python update_version.py 0.2.0` / `--major` / `--minor` / `--patch`
  - Tested: round-trips `0.1.0 → 0.1.1 → 0.1.0`, idempotent.
- **`docs/conf.py`**: `release`/`version` now read from installed metadata — **fixes the `0.0.1` vs `0.1.0` drift** (#26c).
- **`.github/workflows/release.yml`**: on `git push` of a `v*` tag → test matrix (3.10/3.11) → `python -m build` → `twine check` → publish to PyPI via `pypa/gh-action-pypi-publish`. Uses **OIDC Trusted Publishing** (no stored token); API-token fallback documented inline. `workflow_dispatch` allows test+build dry-runs without publishing.

### ✅ Good news
**The `tcri` name is available on PyPI** (HTTP 404 on `pypi.org/pypi/tcri/json`, checked 2026-06-01) — you can claim it.

### 🔧 Manual steps before the first `v0.1.0` tag (can't be automated here)
- [ ] Create the PyPI account/project for `tcri`.
- [ ] Configure a **Trusted Publisher** on PyPI (owner `nceglia`, repo `tcri`, workflow `release.yml`, environment `pypi`) — *or* add a `PYPI_TOKEN` repo secret and switch to the documented token path.
- [ ] Create a `pypi` GitHub Environment (optional protection rules).
- [ ] Then: `python update_version.py 0.1.0 && git tag v0.1.0 && git push --tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)