### PR TITLE
fix: default setup_anndata to X matrix

### DIFF
--- a/tcri/model/_model.py
+++ b/tcri/model/_model.py
@@ -665,7 +665,7 @@ class TCRIModel(BaseModelClass):
     def setup_anndata(
         cls,
         adata: AnnData,
-        layer: str = "X",
+        layer: Optional[str] = None,
         clonotype_key: str = "unique_clone_id",
         phenotype_key: str = "phenotype_col",
         covariate_key: str = "timepoint",
@@ -695,6 +695,10 @@ class TCRIModel(BaseModelClass):
         adata_manager.registry["batch_col"] = batch_key
         cls.register_manager(adata_manager)
         adata.uns["tcri_manager"] = adata_manager
+        if layer is None:
+            adata.uns.pop("tcri_layer", None)
+        else:
+            adata.uns["tcri_layer"] = layer
         return adata
 
     def __init__(

--- a/tcri/utils/_utils.py
+++ b/tcri/utils/_utils.py
@@ -212,7 +212,7 @@ def load_tcri_session(
     *,
     adata_path: Optional[str] = None,
     map_location: Optional[str] = None,
-    layer: Optional[str] = None,   # keep if you added this
+    layer: Optional[str] = None,
 ):
     TCRIModel = _resolve_TCRIModel()
 
@@ -234,10 +234,13 @@ def load_tcri_session(
     _restore_category_order(adata, setup)
 
     # Rebuild AnnData manager
+    setup_layer = layer if layer is not None else setup.get("layer")
+    if setup_layer == "X" and "X" not in adata.layers:
+        setup_layer = None
 
     TCRIModel.setup_anndata(
         adata,
-        layer=layer,
+        layer=setup_layer,
         clonotype_key=setup.get("clone_col", "unique_clone_id"),
         phenotype_key=setup.get("phenotype_col", "phenotype_col"),
         covariate_key=setup.get("covariate_col", "timepoint"),
@@ -560,7 +563,7 @@ def _collect_setup_from_adata_or_model(adata: "_ad.AnnData", model: Any) -> Dict
         cats_key = f"tcri_{key}_categories"
         if cats_key in adata.uns:
             setup[cats_key] = list(map(str, adata.uns[cats_key]))
-    setup["layer"] = adata.uns.get("tcri_layer", "X")
+    setup["layer"] = adata.uns.get("tcri_layer")
     try:
         reg = getattr(model, "adata_manager", None)
         if reg is not None and hasattr(reg, "registry"):
@@ -569,8 +572,11 @@ def _collect_setup_from_adata_or_model(adata: "_ad.AnnData", model: Any) -> Dict
             setup.setdefault("clone_col", r.get("clonotype_col"))
             setup.setdefault("covariate_col", r.get("covariate_col"))
             setup.setdefault("batch_col", r.get("batch_col"))
+            setup_args = r.get("setup_args", {})
+            if isinstance(setup_args, dict) and "layer" in setup_args:
+                setup["layer"] = setup_args["layer"]
             if isinstance(r.get("X"), dict) and "layer" in r["X"]:
-                setup["layer"] = r["X"]["layer"] or "X"
+                setup["layer"] = r["X"]["layer"]
     except Exception:
         pass
     return setup

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,6 @@ def trained_model(synthetic_adata):
     adata = synthetic_adata.copy()
     TCRIModel.setup_anndata(
         adata,
-        layer=None,
         clonotype_key="unique_clone_id",
         phenotype_key="phenotype_col",
         covariate_key="timepoint",

--- a/tests/test_model_setup.py
+++ b/tests/test_model_setup.py
@@ -1,0 +1,129 @@
+import numpy as np
+import pandas as pd
+import pytest
+from anndata import AnnData
+from scvi import REGISTRY_KEYS
+
+from tcri.model._model import TCRIModel
+
+
+def _tiny_adata():
+    obs = pd.DataFrame(
+        {
+            "unique_clone_id": ["c1", "c1", "c2", "c2"],
+            "phenotype_col": ["A", "B", "A", "B"],
+            "timepoint": ["T1", "T1", "T2", "T2"],
+            "patient": ["P1", "P1", "P2", "P2"],
+        },
+        index=[f"cell_{i}" for i in range(4)],
+    )
+    X = np.arange(12, dtype=np.float32).reshape(4, 3) + 1
+    return AnnData(X=X, obs=obs)
+
+
+def test_setup_anndata_defaults_to_x_matrix():
+    adata = _tiny_adata()
+
+    TCRIModel.setup_anndata(adata)
+
+    manager = adata.uns["tcri_manager"]
+    assert manager.registry["setup_args"]["layer"] is None
+    assert "tcri_layer" not in adata.uns
+    np.testing.assert_array_equal(
+        manager.get_from_registry(REGISTRY_KEYS.X_KEY),
+        adata.X,
+    )
+
+
+def test_setup_anndata_explicit_none_uses_x_matrix_with_layers_present():
+    adata = _tiny_adata()
+    adata.layers["counts"] = np.full(adata.shape, 7, dtype=np.float32)
+    adata.layers["other"] = np.full(adata.shape, 11, dtype=np.float32)
+
+    TCRIModel.setup_anndata(adata, layer=None)
+
+    manager = adata.uns["tcri_manager"]
+    assert manager.registry["setup_args"]["layer"] is None
+    assert "tcri_layer" not in adata.uns
+    np.testing.assert_array_equal(
+        manager.get_from_registry(REGISTRY_KEYS.X_KEY),
+        adata.X,
+    )
+
+
+def test_setup_anndata_default_uses_x_matrix_with_one_layer_present():
+    adata = _tiny_adata()
+    adata.layers["counts"] = np.full(adata.shape, 7, dtype=np.float32)
+
+    TCRIModel.setup_anndata(adata)
+
+    manager = adata.uns["tcri_manager"]
+    assert manager.registry["setup_args"]["layer"] is None
+    assert "tcri_layer" not in adata.uns
+    np.testing.assert_array_equal(
+        manager.get_from_registry(REGISTRY_KEYS.X_KEY),
+        adata.X,
+    )
+
+
+def test_setup_anndata_default_uses_x_matrix_with_layers_present():
+    adata = _tiny_adata()
+    adata.layers["counts"] = np.full(adata.shape, 7, dtype=np.float32)
+    adata.layers["other"] = np.full(adata.shape, 11, dtype=np.float32)
+
+    TCRIModel.setup_anndata(adata)
+
+    manager = adata.uns["tcri_manager"]
+    assert manager.registry["setup_args"]["layer"] is None
+    assert "tcri_layer" not in adata.uns
+    np.testing.assert_array_equal(
+        manager.get_from_registry(REGISTRY_KEYS.X_KEY),
+        adata.X,
+    )
+
+
+def test_setup_anndata_accepts_single_explicit_layer():
+    adata = _tiny_adata()
+    adata.layers["counts"] = np.full(adata.shape, 7, dtype=np.float32)
+
+    TCRIModel.setup_anndata(adata, layer="counts")
+
+    manager = adata.uns["tcri_manager"]
+    assert manager.registry["setup_args"]["layer"] == "counts"
+    assert adata.uns["tcri_layer"] == "counts"
+    np.testing.assert_array_equal(
+        manager.get_from_registry(REGISTRY_KEYS.X_KEY),
+        adata.layers["counts"],
+    )
+
+
+@pytest.mark.parametrize(
+    ("layer", "value"),
+    [
+        ("counts", 7),
+        ("other", 11),
+    ],
+)
+def test_setup_anndata_accepts_explicit_layer_when_multiple_layers_present(
+    layer, value
+):
+    adata = _tiny_adata()
+    adata.layers["counts"] = np.full(adata.shape, 7, dtype=np.float32)
+    adata.layers["other"] = np.full(adata.shape, 11, dtype=np.float32)
+
+    TCRIModel.setup_anndata(adata, layer=layer)
+
+    manager = adata.uns["tcri_manager"]
+    assert manager.registry["setup_args"]["layer"] == layer
+    assert adata.uns["tcri_layer"] == layer
+    np.testing.assert_array_equal(
+        manager.get_from_registry(REGISTRY_KEYS.X_KEY),
+        np.full(adata.shape, value, dtype=np.float32),
+    )
+
+
+def test_setup_anndata_rejects_missing_explicit_layer():
+    adata = _tiny_adata()
+
+    with pytest.raises(ValueError, match="other is not a valid key in adata.layers"):
+        TCRIModel.setup_anndata(adata, layer="other")


### PR DESCRIPTION
## Summary
- Change TCRIModel.setup_anndata so the default layer=None follows scvi-tools convention and reads from adata.X.
- Preserve explicit layer behavior for real adata.layers keys such as counts or other.
- Store/load session layer metadata as None for .X instead of the misleading string X, while tolerating legacy setup metadata that used X when no adata.layers['X'] exists.
- Update the trained fixture to exercise the default setup path.

## Why
LayerField interprets a string as an adata.layers key. The old default layer="X" therefore looked for adata.layers["X"] and failed on ordinary AnnData objects where counts live in .X.

## Tests
- NUMBA_CACHE_DIR=/private/tmp/numba-cache MPLCONFIGDIR=/private/tmp/mpl-cache pytest tests/test_model_setup.py -v -> 8 passed
- NUMBA_CACHE_DIR=/private/tmp/numba-cache MPLCONFIGDIR=/private/tmp/mpl-cache pytest tests/ -v -> 17 passed

Coverage added for no layers, one layer, multiple layers, explicit None, counts, other, and missing explicit layer rejection.

Closes Notion #23.