### PR TITLE
fix: reject filtered AnnData in joint_distribution_posterior

### DIFF
--- a/tcri/preprocessing/_preprocessing.py
+++ b/tcri/preprocessing/_preprocessing.py
@@ -273,6 +273,23 @@ def joint_distribution_posterior(
     cov_per_cell = adata.uns["tcri_cov_array_for_cells"]
     clone_labels = adata.obs[clone_col].values
 
+    # Guard against filtered AnnData (view or subset copy). The per-cell arrays in
+    # .uns are stored in the original full-cell space and are NOT subset when adata
+    # is sliced, whereas .obs/.obsm ARE subset. Indexing one with positions derived
+    # from the other then silently misaligns cells (Notion #4). Fail loudly instead
+    # of returning wrong numbers.
+    n_obs = adata.n_obs
+    if len(ct_per_cell) != n_obs or len(cov_per_cell) != n_obs:
+        raise ValueError(
+            "joint_distribution_posterior received an AnnData whose per-cell "
+            f"registration arrays (len {len(ct_per_cell)}) do not match adata.n_obs "
+            f"({n_obs}). This happens when the function is called on a filtered "
+            "AnnData view or subset: the 'tcri_*_array_for_cells' arrays in .uns "
+            "remain in the original full-cell space while .obs/.obsm are subset, so "
+            "cell indices silently misalign. Re-run register_model(...) on the "
+            "filtered AnnData, or pass the full object and filter with `clones=`."
+        )
+
     idx_cov = np.nonzero(cov_per_cell == cov_idx)[0]
     if clones is not None:
         idx_cov = idx_cov[np.isin(clone_labels[idx_cov], clones)]

--- a/tests/test_preprocessing/test_joint_distribution_posterior.py
+++ b/tests/test_preprocessing/test_joint_distribution_posterior.py
@@ -1,0 +1,61 @@
+"""Tests for joint_distribution_posterior view/subset handling (Notion #4 / T7).
+
+Filtered AnnData (views or subset copies) keep their per-cell `.uns` arrays in the
+original full-cell space while `.obs`/`.obsm` are subset. The function used to index
+one with positions derived from the other, silently returning misaligned results.
+It must now raise instead.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from tcri.preprocessing._preprocessing import joint_distribution_posterior
+
+
+def _covariate(adata):
+    return adata.uns["tcri_covariate_categories"][0]
+
+
+def test_jd_posterior_full_adata_ok(trained_model):
+    """Baseline: the full registered AnnData returns a valid distribution."""
+    _, adata = trained_model
+    df = joint_distribution_posterior(adata, _covariate(adata), silent=True)
+    assert isinstance(df, pd.DataFrame)
+    assert df.shape[1] == len(adata.uns["tcri_phenotype_categories"])
+    assert np.all(np.isfinite(df.to_numpy()))
+
+
+def test_jd_posterior_rejects_filtered_view(trained_model):
+    """A cell-filtered view must raise, not silently misalign (Notion #4)."""
+    _, adata = trained_model
+    cov_col = adata.uns["tcri_metadata"]["covariate_col"]
+    mask = np.asarray(adata.obs[cov_col] == _covariate(adata))
+    view = adata[mask]
+    assert view.n_obs < adata.n_obs
+
+    with pytest.raises(ValueError, match=r"filtered|subset|register_model"):
+        joint_distribution_posterior(view, _covariate(adata), silent=True)
+
+
+def test_jd_posterior_rejects_filtered_copy(trained_model):
+    """A cell-filtered copy is also misaligned: .uns stays full-length."""
+    _, adata = trained_model
+    cov_col = adata.uns["tcri_metadata"]["covariate_col"]
+    mask = np.asarray(adata.obs[cov_col] == _covariate(adata))
+    sub = adata[mask].copy()
+    assert sub.n_obs < adata.n_obs
+
+    with pytest.raises(ValueError, match=r"filtered|subset|register_model"):
+        joint_distribution_posterior(sub, _covariate(adata), silent=True)
+
+
+def test_jd_posterior_allows_gene_subset(trained_model):
+    """Var-only subsetting keeps n_obs intact and must NOT trip the guard."""
+    _, adata = trained_model
+    sub = adata[:, : adata.n_vars // 2]
+    assert sub.n_obs == adata.n_obs
+
+    df = joint_distribution_posterior(sub, _covariate(adata), silent=True)
+    assert isinstance(df, pd.DataFrame)
+    assert df.shape[1] == len(adata.uns["tcri_phenotype_categories"])


### PR DESCRIPTION
## Summary
- Add a guard to `joint_distribution_posterior` that detects a filtered AnnData (view or subset copy) and raises an explicit `ValueError` instead of silently returning misaligned results.
- The per-cell arrays in `.uns` (`tcri_ct_array_for_cells`, `tcri_cov_array_for_cells`) stay in the original full-cell space when an AnnData is sliced, while `.obs`/`.obsm` are subset — so indexing one with positions derived from the other misaligns cells.
- Detection compares the per-cell `.uns` array lengths against `adata.n_obs`. Gene-only subsetting (n_obs unchanged) is unaffected.

## Why
Filtered AnnData views silently produced wrong distributions — the worst kind of bug to ship, since callers get plausible-but-incorrect numbers with no error. "Reconstruct indices" isn't viable: the `.uns` arrays are positional/full-space with no retained mapping to the surviving cells, so failing loudly with a remedy (re-run `register_model` on the subset, or pass the full object + `clones=`) is the correct contract.

## Tests
- `NUMBA_CACHE_DIR=... MPLCONFIGDIR=... pytest tests/test_preprocessing/test_joint_distribution_posterior.py -v` -> 4 passed
- Full suite -> 21 passed

New `tests/test_preprocessing/test_joint_distribution_posterior.py` covers: full-adata baseline, cell-filtered view rejected, cell-filtered copy rejected, gene-only subset allowed (no false positive).

Closes Notion #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
